### PR TITLE
Refactor modal components to utilize a new useModal hook for improved…

### DIFF
--- a/src/frontend/src/components/KnowledgeGraph/UI/DeleteConfirmModal.tsx
+++ b/src/frontend/src/components/KnowledgeGraph/UI/DeleteConfirmModal.tsx
@@ -1,4 +1,6 @@
 "use client";
+import { useModal } from '../../../hooks/useModal';
+
 interface DeleteConfirmModalProps {
   isOpen: boolean;
   graphTitle: string;
@@ -7,10 +9,22 @@ interface DeleteConfirmModalProps {
 }
 
 export function DeleteConfirmModal({ isOpen, graphTitle, onConfirm, onCancel }: DeleteConfirmModalProps) {
+  const { modalRef, handleBackdropClick } = useModal({
+    isOpen,
+    onClose: onCancel,
+    enableEscKey: true,
+    enableBackdropClick: true,
+    preventBodyScroll: false
+  });
+
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+    <div 
+      ref={modalRef}
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={handleBackdropClick}
+    >
       <div className="bg-white rounded-lg p-6 max-w-md mx-4">
         <h3 className="text-lg font-semibold text-gray-900 mb-2">Remove Graph</h3>
         <p className="text-gray-600 mb-4">

--- a/src/frontend/src/components/KnowledgeGraph/UI/DeleteConfirmModal.tsx
+++ b/src/frontend/src/components/KnowledgeGraph/UI/DeleteConfirmModal.tsx
@@ -22,6 +22,8 @@ export function DeleteConfirmModal({ isOpen, graphTitle, onConfirm, onCancel }: 
   return (
     <div 
       ref={modalRef}
+      role="dialog"
+      aria-modal="true"
       className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
       onClick={handleBackdropClick}
     >

--- a/src/frontend/src/components/KnowledgeGraph/UI/FullscreenModal.tsx
+++ b/src/frontend/src/components/KnowledgeGraph/UI/FullscreenModal.tsx
@@ -1,6 +1,7 @@
 "use client";
-import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
+import { useModal } from '../../../hooks/useModal';
+import { ModalCloseButton } from './ModalCloseButton';
 
 interface FullscreenModalProps {
   isOpen: boolean;
@@ -10,34 +11,13 @@ interface FullscreenModalProps {
 }
 
 export function FullscreenModal({ isOpen, onClose, children, includeCloseButton}: FullscreenModalProps) {
-  const modalRef = useRef<HTMLDivElement>(null);
-
-  // Handle ESC key press
-  useEffect(() => {
-    const handleEscKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && isOpen) {
-        onClose();
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener('keydown', handleEscKey);
-      // Prevent body scroll when modal is open
-      document.body.style.overflow = 'hidden';
-    }
-
-    return () => {
-      document.removeEventListener('keydown', handleEscKey);
-      document.body.style.overflow = 'unset';
-    };
-  }, [isOpen, onClose]);
-
-  // Handle click outside to close
-  const handleBackdropClick = (event: React.MouseEvent) => {
-    if (event.target === modalRef.current) {
-      onClose();
-    }
-  };
+  const { modalRef, handleBackdropClick } = useModal({
+    isOpen,
+    onClose,
+    enableEscKey: true,
+    enableBackdropClick: true,
+    preventBodyScroll: true
+  });
 
   if (!isOpen) return null;
 
@@ -49,15 +29,12 @@ export function FullscreenModal({ isOpen, onClose, children, includeCloseButton}
     >
       <div className="relative w-full h-full max-w-none max-h-none">
         {/* Close button */}
-        {includeCloseButton && (<button
-          onClick={onClose}
-          className="absolute top-4 right-4 z-10 bg-white hover:bg-gray-50 rounded-full p-2 text-gray-700 shadow-lg border border-gray-200 transition-all duration-200 hover:scale-110"
-          title="Exit fullscreen (ESC)"
-        >
-          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>)}
+        {includeCloseButton && (
+          <ModalCloseButton 
+            onClick={onClose}
+            title="Exit fullscreen (ESC)"
+          />
+        )}
         
         {/* Content */}
         <div className="w-full h-full">

--- a/src/frontend/src/components/KnowledgeGraph/UI/ModalCloseButton.tsx
+++ b/src/frontend/src/components/KnowledgeGraph/UI/ModalCloseButton.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+interface ModalCloseButtonProps {
+  onClick: () => void;
+  title?: string;
+  className?: string;
+}
+
+export function ModalCloseButton({ 
+  onClick, 
+  title = "Close modal (ESC)",
+  className = "absolute top-4 right-4 z-10"
+}: ModalCloseButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`${className} bg-white hover:bg-gray-50 rounded-full p-2 text-gray-700 shadow-lg border border-gray-200 transition-all duration-200 hover:scale-110`}
+      title={title}
+    >
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  );
+}

--- a/src/frontend/src/components/KnowledgeGraph/UI/ModalCloseButton.tsx
+++ b/src/frontend/src/components/KnowledgeGraph/UI/ModalCloseButton.tsx
@@ -16,6 +16,7 @@ export function ModalCloseButton({
       onClick={onClick}
       className={`${className} bg-white hover:bg-gray-50 rounded-full p-2 text-gray-700 shadow-lg border border-gray-200 transition-all duration-200 hover:scale-110`}
       title={title}
+      aria-label={title}
     >
       <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/src/frontend/src/components/KnowledgeGraph/UI/ShareModal.tsx
+++ b/src/frontend/src/components/KnowledgeGraph/UI/ShareModal.tsx
@@ -11,6 +11,8 @@ import {
   ExportFormat,
   ValidationResult
 } from '../../../utils/shareUtils';
+import { useModal } from '../../../hooks/useModal';
+import { ModalCloseButton } from './ModalCloseButton';
 
 interface ShareModalProps {
   isOpen: boolean;
@@ -38,14 +40,22 @@ export function ShareModal({
   const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  if (!isOpen) return null;
-
   const handleClose = () => {
     setMode('main');
     setImportData('');
     setValidationResult(null);
     onClose();
   };
+
+  const { modalRef, handleBackdropClick } = useModal({
+    isOpen,
+    onClose: handleClose,
+    enableEscKey: true,
+    enableBackdropClick: true,
+    preventBodyScroll: false
+  });
+
+  if (!isOpen) return null;
 
   const handleExport = () => {
     try {
@@ -391,8 +401,15 @@ export function ShareModal({
   );
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+    <div 
+      ref={modalRef}
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50"
+      onClick={handleBackdropClick}
+    >
+      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto relative">
+        {/* Close button */}
+        <ModalCloseButton onClick={handleClose} />
+        
         <div className="p-6">
           {mode === 'main' && renderMainMode()}
           {mode === 'export' && renderExportMode()}

--- a/src/frontend/src/components/KnowledgeGraph/UI/ShareModal.tsx
+++ b/src/frontend/src/components/KnowledgeGraph/UI/ShareModal.tsx
@@ -403,6 +403,8 @@ export function ShareModal({
   return (
     <div 
       ref={modalRef}
+      role="dialog"
+      aria-modal="true"
       className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50"
       onClick={handleBackdropClick}
     >

--- a/src/frontend/src/hooks/useModal.tsx
+++ b/src/frontend/src/hooks/useModal.tsx
@@ -1,0 +1,67 @@
+"use client";
+import { useEffect, useRef } from 'react';
+
+interface UseModalOptions {
+  isOpen: boolean;
+  onClose: () => void;
+  enableEscKey?: boolean;
+  enableBackdropClick?: boolean;
+  preventBodyScroll?: boolean;
+}
+
+interface UseModalReturn {
+  modalRef: React.RefObject<HTMLDivElement | null>;
+  handleBackdropClick: (event: React.MouseEvent) => void;
+}
+
+export function useModal({
+  isOpen,
+  onClose,
+  enableEscKey = true,
+  enableBackdropClick = true,
+  preventBodyScroll = false
+}: UseModalOptions): UseModalReturn {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // Handle ESC key press
+  useEffect(() => {
+    const handleEscKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isOpen && enableEscKey) {
+        onClose();
+      }
+    };
+
+    if (isOpen && enableEscKey) {
+      document.addEventListener('keydown', handleEscKey);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscKey);
+    };
+  }, [isOpen, onClose, enableEscKey]);
+
+  // Handle body scroll prevention
+  useEffect(() => {
+    if (isOpen && preventBodyScroll) {
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      if (preventBodyScroll) {
+        document.body.style.overflow = 'unset';
+      }
+    };
+  }, [isOpen, preventBodyScroll]);
+
+  // Handle click outside to close
+  const handleBackdropClick = (event: React.MouseEvent) => {
+    if (enableBackdropClick && event.target === modalRef.current) {
+      onClose();
+    }
+  };
+
+  return {
+    modalRef,
+    handleBackdropClick
+  };
+}

--- a/src/frontend/src/hooks/useModal.tsx
+++ b/src/frontend/src/hooks/useModal.tsx
@@ -40,15 +40,21 @@ export function useModal({
     };
   }, [isOpen, onClose, enableEscKey]);
 
+  // Create a ref to store the original overflow value
+  const originalBodyOverflow = useRef<string>('');
+
   // Handle body scroll prevention
   useEffect(() => {
     if (isOpen && preventBodyScroll) {
+      // Capture the original overflow value
+      originalBodyOverflow.current = document.body.style.overflow;
       document.body.style.overflow = 'hidden';
     }
 
     return () => {
       if (preventBodyScroll) {
-        document.body.style.overflow = 'unset';
+        // Restore the original overflow value
+        document.body.style.overflow = originalBodyOverflow.current;
       }
     };
   }, [isOpen, preventBodyScroll]);


### PR DESCRIPTION
… functionality. This change standardizes modal behavior across DeleteConfirmModal, FullscreenModal, and ShareModal, enhancing user experience with consistent backdrop click handling and ESC key functionality. Additionally, a new ModalCloseButton component is introduced for better close button management.
This pull request refactors modal components in the frontend to centralize common modal behaviors using a new `useModal` hook. It also introduces a reusable `ModalCloseButton` component for consistent styling and functionality across modals. These changes improve code maintainability by reducing duplication and standardizing modal behavior.

### Refactoring modal behavior:

* **New `useModal` hook**: Added a reusable hook in `src/hooks/useModal.tsx` to manage modal-related behaviors such as handling ESC key presses, backdrop clicks, and preventing body scroll. This hook is now used across multiple modal components.

* **Integration of `useModal` in `DeleteConfirmModal`**: Updated `DeleteConfirmModal` to use the `useModal` hook for handling modal behavior, replacing inline logic with centralized functionality. [[1]](diffhunk://#diff-00a2f348aeaa09a0664e9c33ccbf7a8fe96607303394c8a44ac61415ca7c2e56R2-R3) [[2]](diffhunk://#diff-00a2f348aeaa09a0664e9c33ccbf7a8fe96607303394c8a44ac61415ca7c2e56R12-R27)

* **Integration of `useModal` in `FullscreenModal`**: Refactored `FullscreenModal` to use the `useModal` hook, removing duplicated logic for ESC key handling, backdrop clicks, and body scroll prevention. [[1]](diffhunk://#diff-f2e01cab6b827334148c73596a199ca218c03021277ecf5417aabff059aa27d3L2-R4) [[2]](diffhunk://#diff-f2e01cab6b827334148c73596a199ca218c03021277ecf5417aabff059aa27d3L13-R20)

* **Integration of `useModal` in `ShareModal`**: Updated `ShareModal` to use the `useModal` hook, simplifying its modal behavior management and ensuring consistency. [[1]](diffhunk://#diff-21362306f32776c62a4d59cba4e23350daafcbec74ed3d60949b25814a7fa057R14-R15) [[2]](diffhunk://#diff-21362306f32776c62a4d59cba4e23350daafcbec74ed3d60949b25814a7fa057L41-R59) [[3]](diffhunk://#diff-21362306f32776c62a4d59cba4e23350daafcbec74ed3d60949b25814a7fa057L394-R412)

### Reusable components:

* **New `ModalCloseButton` component**: Created a reusable `ModalCloseButton` in `src/components/KnowledgeGraph/UI/ModalCloseButton.tsx` to standardize the appearance and behavior of close buttons across modal components. Integrated this component into `FullscreenModal` and `ShareModal`. [[1]](diffhunk://#diff-86e96a0110a2c1d5e31e7aaa411f229646498a3310d956bb83477d9796f2f7c5R1-R25) [[2]](diffhunk://#diff-f2e01cab6b827334148c73596a199ca218c03021277ecf5417aabff059aa27d3L52-R37) [[3]](diffhunk://#diff-21362306f32776c62a4d59cba4e23350daafcbec74ed3d60949b25814a7fa057L394-R412)