### PR TITLE
Implement Turnstile reset functionality in StreamingGraphGenerator an…

### DIFF
--- a/src/frontend/src/components/KnowledgeGraph/UI/TurnstileWidget.tsx
+++ b/src/frontend/src/components/KnowledgeGraph/UI/TurnstileWidget.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useCallback, useRef, forwardRef } from 'react';
+import { useState, useCallback, useRef, forwardRef, useImperativeHandle } from 'react';
 import { Turnstile, TurnstileInstance } from '@marsidev/react-turnstile';
 
 interface TurnstileWidgetProps {
@@ -32,14 +32,15 @@ export const TurnstileWidget = forwardRef<{ resetWidget?: () => void }, Turnstil
       }
     }, []);
 
-    // Expose reset function via ref callback
+    // Expose resetWidget method using useImperativeHandle
+    useImperativeHandle(ref, () => ({
+      resetWidget: reset
+    }), [reset]);
+
+    // Set turnstile ref callback
     const setTurnstileRef = useCallback((instance: TurnstileInstance | null) => {
       turnstileRef.current = instance;
-      if (instance) {
-        // Attach reset function to parent
-        (ref as React.MutableRefObject<{ resetWidget?: () => void }>).current = { resetWidget: reset };
-      }
-    }, [ref, reset]);
+    }, []);
 
     return (
       <div ref={containerRef} className={`flex justify-center overflow-hidden transition-all duration-300 ${!isVisible ? 'h-0' : ''}`}>

--- a/src/frontend/src/components/KnowledgeGraph/UI/TurnstileWidget.tsx
+++ b/src/frontend/src/components/KnowledgeGraph/UI/TurnstileWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { useEffect, useRef, useState } from 'react';
-import { Turnstile } from '@marsidev/react-turnstile';
+import { useState, useCallback, useRef, forwardRef } from 'react';
+import { Turnstile, TurnstileInstance } from '@marsidev/react-turnstile';
 
 interface TurnstileWidgetProps {
   onVerify: (token: string) => void;
@@ -8,48 +8,54 @@ interface TurnstileWidgetProps {
   siteKey: string;
 }
 
-export function TurnstileWidget({ onVerify, onError, siteKey }: TurnstileWidgetProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [isVisible, setIsVisible] = useState(true);
+export const TurnstileWidget = forwardRef<{ resetWidget?: () => void }, TurnstileWidgetProps>(
+  ({ onVerify, onError, siteKey }, ref) => {
+    const [isVisible, setIsVisible] = useState(true);
+    const turnstileRef = useRef<TurnstileInstance | null>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const checkVisibility = () => {
-      if (!containerRef.current) return;
-      
-      // Look for the hidden input that indicates an invisible Turnstile
-      const hiddenInput = containerRef.current.querySelector('input[name="cf-turnstile-response"][type="hidden"]');
-      
-      if (hiddenInput) {
-        setIsVisible(false);
-      } else {
+    const handleSuccess = useCallback((token: string) => {
+      onVerify(token);
+      // Hide widget after successful verification
+      setIsVisible(false);
+    }, [onVerify]);
+
+    const handleError = useCallback(() => {
+      setIsVisible(true); // Show widget on error
+      onError?.();
+    }, [onError]);
+
+    const reset = useCallback(() => {
+      if (turnstileRef.current?.reset) {
+        turnstileRef.current.reset();
         setIsVisible(true);
       }
-    };
+    }, []);
 
-    // Check immediately and then set up polling
-    const timer = setTimeout(checkVisibility, 3000);
-    const interval = setInterval(checkVisibility, 4000);
+    // Expose reset function via ref callback
+    const setTurnstileRef = useCallback((instance: TurnstileInstance | null) => {
+      turnstileRef.current = instance;
+      if (instance) {
+        // Attach reset function to parent
+        (ref as React.MutableRefObject<{ resetWidget?: () => void }>).current = { resetWidget: reset };
+      }
+    }, [ref, reset]);
 
-    return () => {
-      clearTimeout(timer);
-      clearInterval(interval);
-    };
-  }, []);
+    return (
+      <div ref={containerRef} className={`flex justify-center overflow-hidden transition-all duration-300 ${!isVisible ? 'h-0' : ''}`}>
+        <Turnstile
+          ref={setTurnstileRef}
+          siteKey={siteKey}
+          onSuccess={handleSuccess}
+          onError={handleError}
+          options={{
+            theme: 'light',
+            size: 'normal'
+          }}
+        />
+      </div>
+    );
+  }
+);
 
-  return (
-    <div 
-      ref={containerRef} 
-      className={`flex justify-center overflow-hidden ${!isVisible ? 'h-0' : ''}`}
-    >
-      <Turnstile
-        siteKey={siteKey}
-        onSuccess={onVerify}
-        onError={onError}
-        options={{
-          theme: 'light',
-          size: 'normal',
-        }}
-      />
-    </div>
-  );
-}
+TurnstileWidget.displayName = 'TurnstileWidget';


### PR DESCRIPTION
…d enhance TurnstileWidget to support external reset calls. Add error handling for expired security verification tokens and retry logic for pending requests.

This pull request enhances the security verification process for streaming graph generation by integrating improved handling of Turnstile CAPTCHA tokens. It introduces mechanisms to reset the Turnstile widget, retry pending requests after re-verification, and handle token expiration gracefully. Additionally, it refactors the `TurnstileWidget` component to support a reset function and improves its usability.

### Security Verification Enhancements:

* **Token Expiration Handling**: Added logic in `useStreamingGraph` to detect expired or invalid Turnstile tokens (HTTP 400 errors) and store the pending request for retry after re-verification. This ensures smoother handling of security verification failures. (`src/frontend/src/hooks/useStreamingGraph.tsx`, [src/frontend/src/hooks/useStreamingGraph.tsxR94-R117](diffhunk://#diff-4bb37fd842cf5c04d0c89c38e0e717e3e1fde84ca0a45c3926847e1c24df2bf2R94-R117))
* **Retry Mechanism**: Implemented a `retryPendingRequest` function that retries the original request with a new Turnstile token after successful re-verification. (`src/frontend/src/hooks/useStreamingGraph.tsx`, [src/frontend/src/hooks/useStreamingGraph.tsxR269-R290](diffhunk://#diff-4bb37fd842cf5c04d0c89c38e0e717e3e1fde84ca0a45c3926847e1c24df2bf2R269-R290))

### Turnstile Widget Improvements:

* **Reset Functionality**: Refactored the `TurnstileWidget` component to use `forwardRef`, exposing a `resetWidget` method for resetting the CAPTCHA widget programmatically. (`src/frontend/src/components/KnowledgeGraph/UI/TurnstileWidget.tsx`, [src/frontend/src/components/KnowledgeGraph/UI/TurnstileWidget.tsxL2-R61](diffhunk://#diff-286f26612bf25a96f584bfcbbfc0e70bde17c5f9fa139a689fd491f1cd463bf5L2-R61))
* **Callback Integration**: Updated `StreamingGraphGenerator` to set up a Turnstile reset callback and handle verification events using the new `handleTurnstileVerify` function. (`src/frontend/src/components/KnowledgeGraph/StreamingGraphGenerator.tsx`, [[1]](diffhunk://#diff-ac3d6362b899f6d234a8ca686c3f5cf1d17cb060f8f117dfbacb877291c96985R64-R72) [[2]](diffhunk://#diff-ac3d6362b899f6d234a8ca686c3f5cf1d17cb060f8f117dfbacb877291c96985R95-R101)

### Code Refactoring:

* **Improved Reusability**: Added new hooks (`setTurnstileRemountCallback`) and refactored existing code to centralize Turnstile-related logic, improving maintainability. (`src/frontend/src/hooks/useStreamingGraph.tsx`, [src/frontend/src/hooks/useStreamingGraph.tsxR269-R290](diffhunk://#diff-4bb37fd842cf5c04d0c89c38e0e717e3e1fde84ca0a45c3926847e1c24df2bf2R269-R290))