### PR TITLE
Intuitive explore deeper

### DIFF
--- a/src/frontend/src/components/KnowledgeGraph/index.tsx
+++ b/src/frontend/src/components/KnowledgeGraph/index.tsx
@@ -20,6 +20,7 @@ export default function KnowledgeGraph() {
   // Ref to store the streaming reset function and input setter
   const streamingResetRef = useRef<(() => void) | null>(null);
   const setInputSubjectRef = useRef<((subject: string) => void) | null>(null);
+  const generateFromNodeRef = useRef<((subject: string) => Promise<void>) | null>(null);
 
   const {
     allGraphs,
@@ -70,6 +71,11 @@ export default function KnowledgeGraph() {
     setInputSubjectRef.current = setSubjectFn;
   };
 
+  // Handle generation function registration
+  const handleSetGenerateFromNode = (generateFn: (subject: string) => Promise<void>) => {
+    generateFromNodeRef.current = generateFn;
+  };
+
 
   // Keyboard shortcuts
   useKeyboardShortcuts({
@@ -101,6 +107,18 @@ export default function KnowledgeGraph() {
       setInputSubjectRef.current(newSubject);
     }
   }, [graphMetadata.subject]);
+
+  // Handle node deselection
+  const handleNodeDeselect = useCallback(() => {
+    // Clear any node-specific state if needed
+  }, []);
+
+  // Handle generation from selected node
+  const handleGenerateFromNode = useCallback(async (subject: string) => {
+    if (generateFromNodeRef.current) {
+      await generateFromNodeRef.current(subject);
+    }
+  }, []);
 
   // Get delete confirmation graph title
   const deleteConfirmGraph = showDeleteConfirm ? allGraphs.find(g => g.id === showDeleteConfirm) : null;
@@ -161,6 +179,7 @@ export default function KnowledgeGraph() {
           onToast={handleToast}
           onResetState={handleStreamingResetState}
           onSetInputSubject={handleSetInputSubject}
+          onSetGenerateFromNode={handleSetGenerateFromNode}
         />
         
         {/* Graph Display Container */}
@@ -192,6 +211,8 @@ export default function KnowledgeGraph() {
               metadata={graphMetadata}
               graphId={currentGraph?.id}
               onNodeSelect={handleNodeSelect}
+              onNodeDeselect={handleNodeDeselect}
+              onGenerateFromNode={handleGenerateFromNode}
             />
           )}
         </div>

--- a/src/frontend/src/hooks/useGraphData.tsx
+++ b/src/frontend/src/hooks/useGraphData.tsx
@@ -25,13 +25,20 @@ export function useGraphData() {
     setAllGraphs(allGraphsData);
     setVisibleGraphs(visibleGraphsData);
     
-    // Set initial graph to the latest (most recent)
+    // Set initial graph from localStorage or default to latest
     if (visibleGraphsData.length > 0) {
-      // Find the latest graph by createdAt timestamp
-      const latestGraphIndex = visibleGraphsData.reduce((latestIndex, graph, index) => {
-        return graph.createdAt > visibleGraphsData[latestIndex].createdAt ? index : latestIndex;
-      }, 0);
-      setCurrentGraphIndex(latestGraphIndex);
+      const savedIndex = loadFromLocalStorage<number>(STORAGE_KEYS.CURRENT_GRAPH_INDEX, -1);
+      
+      if (savedIndex >= 0 && savedIndex < visibleGraphsData.length) {
+        // Use saved index if valid
+        setCurrentGraphIndex(savedIndex);
+      } else {
+        // Fallback to latest graph by createdAt timestamp
+        const latestGraphIndex = visibleGraphsData.reduce((latestIndex, graph, index) => {
+          return graph.createdAt > visibleGraphsData[latestIndex].createdAt ? index : latestIndex;
+        }, 0);
+        setCurrentGraphIndex(latestGraphIndex);
+      }
     }
   }, []);
 
@@ -41,6 +48,13 @@ export function useGraphData() {
       saveToLocalStorage(STORAGE_KEYS.GRAPHS, allGraphs);
     }
   }, [allGraphs]);
+
+  // Save current graph index to localStorage whenever it changes
+  useEffect(() => {
+    if (visibleGraphs.length > 0) {
+      saveToLocalStorage(STORAGE_KEYS.CURRENT_GRAPH_INDEX, currentGraphIndex);
+    }
+  }, [currentGraphIndex, visibleGraphs.length]);
 
   // Navigation functions
   const goToPreviousGraph = useCallback(() => {
@@ -94,11 +108,12 @@ export function useGraphData() {
     setVisibleGraphs(newVisibleGraphs);
     
     // Adjust current index if necessary
-    setCurrentGraphIndex(prev => prev >= newVisibleGraphs.length ? Math.max(0, newVisibleGraphs.length - 1) : prev);
+    const newIndex = currentGraphIndex >= newVisibleGraphs.length ? Math.max(0, newVisibleGraphs.length - 1) : currentGraphIndex;
+    setCurrentGraphIndex(newIndex);
     
     const removedGraph = allGraphs.find(g => g.id === graphId);
     return removedGraph ? getGraphTitle(removedGraph) : 'Unknown Graph';
-  }, [allGraphs, visibleGraphs]);
+  }, [allGraphs, visibleGraphs, currentGraphIndex]);
 
   // Get current graph
   const currentGraph = visibleGraphs[currentGraphIndex];

--- a/src/frontend/src/utils/constants.ts
+++ b/src/frontend/src/utils/constants.ts
@@ -125,5 +125,6 @@ export const EXAMPLE_GRAPHS: StoredGraph[] = [
 export const STORAGE_KEYS = {
   GRAPHS: 'knowledge-graphs',
   PREFERENCES: 'user-preferences',
-  SELECTED_MODEL: 'selected-model'
+  SELECTED_MODEL: 'selected-model',
+  CURRENT_GRAPH_INDEX: 'current-graph-index'
 } as const;


### PR DESCRIPTION
This pull request introduces enhancements to the `KnowledgeGraph` feature, focusing on node-specific interactions, improved state management, and user experience improvements. Key changes include adding support for generating graphs from selected nodes, implementing node deselection callbacks, and persisting the current graph index in localStorage for improved navigation.

### Node-specific interactions:
* [`src/frontend/src/components/KnowledgeGraph/GraphVisualization.tsx`](diffhunk://#diff-2e5fad42a45b6676576259f7877b496453f0ec6ffa7c21b74b4fe2e4fa743e25R23-R59): Added callbacks `onNodeDeselect` and `onGenerateFromNode` to handle node deselection and graph generation from selected nodes. Implemented UI elements for previewing and triggering generation from selected nodes. [[1]](diffhunk://#diff-2e5fad42a45b6676576259f7877b496453f0ec6ffa7c21b74b4fe2e4fa743e25R23-R59) [[2]](diffhunk://#diff-2e5fad42a45b6676576259f7877b496453f0ec6ffa7c21b74b4fe2e4fa743e25L85-R129) [[3]](diffhunk://#diff-2e5fad42a45b6676576259f7877b496453f0ec6ffa7c21b74b4fe2e4fa743e25R327-R368)

### State management:
* [`src/frontend/src/components/KnowledgeGraph/StreamingGraphGenerator.tsx`](diffhunk://#diff-ac3d6362b899f6d234a8ca686c3f5cf1d17cb060f8f117dfbacb877291c96985R15-R18): Added `onSetGenerateFromNode` to expose the `generateFromNode` function for generating graphs from specific nodes. Utilized `useEffect` to register this function with the parent component. [[1]](diffhunk://#diff-ac3d6362b899f6d234a8ca686c3f5cf1d17cb060f8f117dfbacb877291c96985R15-R18) [[2]](diffhunk://#diff-ac3d6362b899f6d234a8ca686c3f5cf1d17cb060f8f117dfbacb877291c96985R139-R171)
* [`src/frontend/src/components/KnowledgeGraph/index.tsx`](diffhunk://#diff-d936aea1de2e47df0a3ede18d8ebe298250e448a22400162fba20ec6ef71cdacR23): Integrated the `generateFromNode` function into the main `KnowledgeGraph` component and added handling for node deselection. [[1]](diffhunk://#diff-d936aea1de2e47df0a3ede18d8ebe298250e448a22400162fba20ec6ef71cdacR23) [[2]](diffhunk://#diff-d936aea1de2e47df0a3ede18d8ebe298250e448a22400162fba20ec6ef71cdacR74-R78) [[3]](diffhunk://#diff-d936aea1de2e47df0a3ede18d8ebe298250e448a22400162fba20ec6ef71cdacR111-R122) [[4]](diffhunk://#diff-d936aea1de2e47df0a3ede18d8ebe298250e448a22400162fba20ec6ef71cdacR182) [[5]](diffhunk://#diff-d936aea1de2e47df0a3ede18d8ebe298250e448a22400162fba20ec6ef71cdacR214-R215)

### User experience improvements:
* [`src/frontend/src/hooks/useGraphData.tsx`](diffhunk://#diff-7c1d0517fc48ea561c7a00f9d269c7825534f064702ad7b48ed783f416904552L28-R42): Enhanced graph navigation by persisting the current graph index in localStorage and defaulting to the saved graph index when loading graphs. Adjusted state updates for better consistency. [[1]](diffhunk://#diff-7c1d0517fc48ea561c7a00f9d269c7825534f064702ad7b48ed783f416904552L28-R42) [[2]](diffhunk://#diff-7c1d0517fc48ea561c7a00f9d269c7825534f064702ad7b48ed783f416904552R52-R58) [[3]](diffhunk://#diff-7c1d0517fc48ea561c7a00f9d269c7825534f064702ad7b48ed783f416904552L97-R116)
* [`src/frontend/src/utils/constants.ts`](diffhunk://#diff-d3559970c089d0e82d50904c5cf5013f8fa8fae8caa9a4221902d8401a74d9a2L128-R129): Added a new storage key `CURRENT_GRAPH_INDEX` to support graph index persistence.